### PR TITLE
Added Browser Dependency

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -59,4 +59,5 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation platform('com.google.firebase:firebase-bom:26.6.0')
     implementation 'com.google.firebase:firebase-analytics'
+    mplementation 'androidx.browser:browser:1.2.0'
 }


### PR DESCRIPTION
Everytime, I pressed for OTP my app crashing.Finally,this thing help me out.
Now,browser can be opened up easily for verification.
This change basically allow firebase to access the mobile browser for verfication.