### PR TITLE
Solved Password Invalid Issue due to Pre & Post Spaces

### DIFF
--- a/lib/authentication/email_password/utils/authentication.dart
+++ b/lib/authentication/email_password/utils/authentication.dart
@@ -27,8 +27,8 @@ class Authentication {
 
     try {
       UserCredential userCredential = await auth.signInWithEmailAndPassword(
-        email: email,
-        password: password,
+        email: email.trim(),
+        password: password.trim(),
       );
       user = userCredential.user;
     } on FirebaseAuthException catch (e) {
@@ -63,8 +63,8 @@ class Authentication {
 
     try {
       UserCredential userCredential = await auth.createUserWithEmailAndPassword(
-        email: email,
-        password: password,
+        email: email.trim(),
+        password: password.trim(),
       );
 
       user = userCredential.user;

--- a/lib/authentication/email_password/widgets/register_form.dart
+++ b/lib/authentication/email_password/widgets/register_form.dart
@@ -142,9 +142,9 @@ class RegisterFormState extends State<RegisterForm> {
                         if (_registerFormKey.currentState!.validate()) {
                           User? user =
                               await Authentication.registerUsingEmailPassword(
-                            name: _nameController.text,
-                            email: _emailController.text,
-                            password: _passwordController.text,
+                            name: _nameController.text.trim(),
+                            email: _emailController.text.trim(),
+                            password: _passwordController.text.trim(),
                             context: context,
                           );
 

--- a/lib/authentication/email_password/widgets/sign_in_form.dart
+++ b/lib/authentication/email_password/widgets/sign_in_form.dart
@@ -106,8 +106,8 @@ class SignInFormState extends State<SignInForm> {
                           User? user =
                               await Authentication.signInUsingEmailPassword(
                             context: context,
-                            email: _emailController.text,
-                            password: _passwordController.text,
+                            email: _emailController.text.trim(),
+                            password: _passwordController.text.trim(),
                           );
 
                           if (user != null) {


### PR DESCRIPTION
Hello, Om Here,

While running the project I get to know that there is an issue with Firebase Authentication implementation and that is while auto-completing passwords including extra space at the end which is included in the password, leading to the wrong password while entering again. 

So, I solved that issue by removing extra space from both sides and updating the code.

PR Includes Changes in the Following Files
--------------------------------------
1. sign_in_form.dart
2. register_form.dart
3. authentication.dart

Applied trim() operation on all the data before passing it to the actual function. that solved the issue...

Thanks for creating such real helpful project. Please merge this PR because it might cause issues for other people.

I am looking forward contribute more to this repo...

Happy Coding, Thank You
-- Om Jogani
 